### PR TITLE
Fix the inability to upload files to Sharkey drive & a few small changes

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -10,7 +10,7 @@ WorkingDirectory=__INSTALL_DIR__/
 Environment="PATH=__PATH_WITH_NODEJS__"
 Environment="NODE_OPTIONS=--max-old-space-size=8192"
 Environment="NODE_ENV=production"
-ExecStart=__NODEJS_DIR__/npm start
+ExecStart=__NODEJS_DIR__/pnpm start
 TimeoutSec=60
 Restart=always
 
@@ -34,7 +34,7 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 LockPersonality=yes
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation @privileged
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation
 
 # Denying access to capabilities that should not be relevant for webapps
 # Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,10 +1,3 @@
 ## 🌎 A Sharkish microblogging platform 🦈🚀 
 
 _Sharkey_ is an Misskey fork following upstream changes when possible, with added features!
-
-### ⚠️ PLEASE READ CAREFULLY ⚠️
-
-**Sharkey** requires **redis** version **7**, but YunoHost does not currently support this version.
-Some functions will not be available if you install this package.
-
-I advise you to wait for the release of _Bookworm_ Debian 12.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,10 +1,3 @@
 ## 🌎 Une plateforme de microblogging 🦈🚀 
 
 _Sharkey_ est un fork de Misskey qui suit les changements en amont lorsque c'est possible, avec des fonctionnalités supplémentaires !
-
-### ⚠️ A LIRE ATTENTIVEMENT ⚠️
-
-Attention **Sharkey** nécessite la version **7** de **redis** hors YunoHost ne permet pas actuellement de bénéficier de cette version.
-Certaines fonctions ne seront pas disponible si vous installez ce package.
-
-Je vous conseille d'attendre la sortie de _Bookworm_ Debian 12.


### PR DESCRIPTION
## Problem

- I was unable to upload files to the Sharkey drive after install
- The systemd service launches sharkey with npm, not pnpm [as suggested by sharkey](https://docs.joinsharkey.org/docs/install/fresh/#with-systemd)
- The README still says to await for the release of Yunohost for Debian 12 when [this has already been released](https://forum.yunohost.org/t/yunohost-12-0-bookworm-release-sortie-de-yunohost-12-0-bookworm/31673)

## Solution

- I altered the systemd sandboxing to allow sharkey to create files in the drive
- I replaced npm start with pnpm start
- I removed the redundant comment from the DESCRIPTION.md's

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

Thanks!
- Loowiz