### PR TITLE
Add `pkg-config` dependency

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -55,7 +55,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages ="ffmpeg, postgresql, git, build-essential, redis-server"
+    packages ="ffmpeg, postgresql, git, build-essential, redis-server, pkg-config"
 
     [resources.database]
     type = "postgresql"


### PR DESCRIPTION
## Problem

- Per [this log](https://paste.yunohost.org/raw/jadalunexu) `pkg-config` is a required dep for building sharkey

## Solution

- Add the dep

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
